### PR TITLE
Fix dplyr groups

### DIFF
--- a/pkg/R/utils.R
+++ b/pkg/R/utils.R
@@ -135,18 +135,26 @@ has_groups <- function(frm){
 }
 
 # get groups
-groups <- function(dat, frm){
-  grp <- character()
-  # dplyr compatability:
-  if (inherits(dat,"grouped_df")){
-   grp <- sapply(attr(dat,"vars"), as.character)
+groups <- function(dat, frm) {
+  # dplyr groups
+  dat_groups <- if (requireNamespace("dplyr", quietly = TRUE)) {
+    dplyr::group_vars(dat)
+  } else {
+    if (inherits(dat, "grouped_df")) {
+      warning("Dataframe is grouped but dplyr is not available. Ignoring dataframe groups.", call. = FALSE)
+    }
+    character()
   }
-  # also take grouping from formula
-  if (has_groups(frm)){
+
+  # formula groups
+  frm_groups <- if (has_groups(frm)) {
     n <- length(frm)
-    grp <- c(grp,all.vars(frm[[n]][[3]]))
+    all.vars(frm[[n]][[3]])
+  } else {
+    character()
   }
-  unique(grp)
+
+  unique(c(dat_groups, frm_groups))
 }
 
 # remove group statement from formula

--- a/pkg/inst/tinytest/test_groups.R
+++ b/pkg/inst/tinytest/test_groups.R
@@ -1,0 +1,10 @@
+df <- data.frame(a = c(1, 2), b = c(3, 4), c = c(5, 6), d = c(7, 8))
+
+# Check group extraction from formula.
+expect_equal(simputation:::groups(df, a ~ b | c), c("c"))
+expect_equal(simputation:::groups(df, a ~ b | c + d), c("c", "d"))
+
+# Check dplyr group extraction.
+grouped_df <- dplyr::group_by(df, d)
+expect_equal(simputation:::groups(grouped_df, a ~ b), c("d"))
+expect_equal(simputation:::groups(grouped_df, a ~ b | c), c("d", "c"))


### PR DESCRIPTION
Due to a change in the implementation of dplyr groups, the old compatibility silently broke.
This change fixes compatability using a dplyr interface function, to prevent it from breaking silently again.